### PR TITLE
Drop requirement for letsencrypt cert in aws enterprise module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,10 @@ module "aws" {
   # - bastion with proxy
   # - execute terraform from VPC
   management_api = var.management_api
+
+  # if the TLS cert and key are provided, we will want to use
+  # them instead of asking for a Let's Encrypt cert.
+  lets_encrypt = var.lets_encrypt
 }
 
 # Get the AWS_REGION used by the aws provider

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ module "astronomer" {
   base_domain           = module.aws.base_domain
   db_connection_string  = module.aws.db_connection_string
   tls_cert              = var.tls_cert == "" ? module.aws.tls_cert : var.tls_cert
-  tls_key               = var.tls_cert == "" ? module.aws.tls_key : var.tls_key
+  tls_key               = var.tls_key == "" ? module.aws.tls_key : var.tls_key
 }
 
 data "aws_lambda_invocation" "elb_name" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "aws" {
   source  = "astronomer/astronomer-aws/aws"
-  version = "1.1.29"
+  version = "1.1.57"
   # source                        = "../terraform-aws-astronomer-aws"
   deployment_id                 = var.deployment_id
   admin_email                   = var.email

--- a/main.tf
+++ b/main.tf
@@ -52,8 +52,8 @@ module "astronomer" {
   astronomer_version    = var.astronomer_version
   base_domain           = module.aws.base_domain
   db_connection_string  = module.aws.db_connection_string
-  tls_cert              = module.aws.tls_cert
-  tls_key               = module.aws.tls_key
+  tls_cert              = var.tls_cert == "" ? module.aws.tls_cert : var.tls_cert
+  tls_key               = var.tls_cert == "" ? module.aws.tls_key : var.tls_key
 }
 
 data "aws_lambda_invocation" "elb_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,3 @@
-output "bastion_proxy_command" {
-  value = module.aws.bastion_proxy_command
-}
-
 output "windows_debug_box_password" {
   value = module.aws.windows_debug_box_password
 }

--- a/variables.tf
+++ b/variables.tf
@@ -100,13 +100,13 @@ variable "cluster_version" {
 variable "tls_cert" {
   default     = ""
   type        = string
-  description = "The signed certificate for the Astronomer Load Balancer. It should be signed by a certificate authorize and should have common name *.base_domain. Ignored if var.lets_encrypt is true."
+  description = "The signed certificate for the Astronomer Load Balancer. It should be signed by a certificate authorize and should have common name *.base_domain."
 }
 
 variable "tls_key" {
   default     = ""
   type        = string
-  description = "The private key corresponding to the signed certificate tls_cert. Ignored if var.lets_encrypt is true"
+  description = "The private key corresponding to the signed certificate tls_cert."
 }
 
 variable "lets_encrypt" {

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,20 @@ variable "cluster_version" {
   default = "1.13"
   type    = string
 }
+
+variable "tls_cert" {
+  default     = ""
+  type        = string
+  description = "The signed certificate for the Astronomer Load Balancer. It should be signed by a certificate authorize and should have common name *.base_domain. Ignored if var.lets_encrypt is true."
+}
+
+variable "tls_key" {
+  default     = ""
+  type        = string
+  description = "The private key corresponding to the signed certificate tls_cert. Ignored if var.lets_encrypt is true"
+}
+
+variable "lets_encrypt" {
+  default = true
+  type    = bool
+}


### PR DESCRIPTION
* Add option to use cert other than letsencrypt
* Related to astronomer/issues#515