### PR TITLE
Allow configuration of DB and Node instance types

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,8 @@ module "aws" {
   ten_dot_what_cidr             = var.ten_dot_what_cidr
   cluster_type                  = var.cluster_type
   cluster_version               = var.cluster_version
+  worker_instance_type          = var.worker_instance_type
+  db_instance_type              = var.db_instance_type
   # It makes the installation easier to leave
   # this public, then just flip it off after
   # everything is deployed.

--- a/variables.tf
+++ b/variables.tf
@@ -119,3 +119,13 @@ variable "lets_encrypt" {
   default = true
   type    = bool
 }
+
+variable "db_instance_type" {
+  default = "db.r4.large"
+  type    = string
+}
+
+variable "worker_instance_type" {
+  default = "m5.xlarge"
+  type    = string
+}


### PR DESCRIPTION
- Add variables for `db_instance_type` and `worker_instance_type`
- Related to astronomer/issues#667