### PR TITLE
Bastion subnets + cert and db configuration updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,31 @@ If using private mangement API, you must have some way to access the API. There 
 - optional private management API
 
 ![Astronomer Private Cloud Architecture](images/Astronomer_AWS_Architecture_EE.svg)
+
+# Configurations
+
+## Certificate
+By default, a certificate will be generated from LetsEncrypt. Certificates can be used from ther sources if they can be exported into plain text PEM format:
+```
+  lets_encrypt          = false
+  tls_cert              = <<EOF
+-----BEGIN CERTIFICATE-----
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+-----END CERTIFICATE-----
+EOF
+  tls_key               = <<EOF
+-----BEGIN PRIVATE KEY-----
+-----END PRIVATE KEY-----
+EOF
+}
+}
+```
+## Multiple AZ Database
+To deploy the Aurora database to multiple availability zones, additional replicas and subnets in different AZs need to be specified:
+
+```
+  db_replica_count      = 2
+  db_subnets            = []
+```
+**Note:** `db_subnets` only need to be specified if deploying to pre-existing subnets. Otherwise, all subnets will be created fresh and the `db_subnets` parameter can be excluded from the enterprise module. 

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ module "aws" {
   route53_domain                = var.route53_domain
   vpc_id                        = var.vpc_id
   private_subnets               = var.private_subnets
+  public_subnets                = [var.bastion_subnet]
   db_subnets                    = var.db_subnets
   enable_bastion                = var.enable_bastion
   enable_windows_box            = var.enable_windows_box

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "db_subnets" {
   description = "This variable does nothing unless vpc_id is also set. Specify the subnet IDs in which the DB will be deployed. If not provided, it will fall back to private_subnets."
 }
 
+variable "bastion_subnet" {
+  default     = ""
+  description = "Public subnet ID for use with bastion host when enable_bastion variable is true and using bring-your-own VPC configuration (vpc_id and private_subnets provided by user)."
+  type        = string
+}
+
 variable "enable_windows_box" {
   default     = false
   description = "Launch a Windows instance with Firefox installed in a public subnet?"
@@ -50,7 +56,7 @@ variable "enable_windows_box" {
 
 variable "enable_bastion" {
   default     = false
-  description = "Launch a bastion in a public subnet? For this to work, you must include 1 subnet id in the public_subets variable"
+  description = "Launch a bastion in a public subnet. For this to work with bring-your-own VPC configuration, you must include a public subnet id in the bastion_subnets variable. This should be in the same VPC as vpc_id and the provided private subnets."
   type        = bool
 }
 


### PR DESCRIPTION
- Add bastion_subnet variable as optional public subnet for use when bastion_enabled and bringing your own subnets
- Add README info on configuring multi-az aurora DB and using your own certs
- Related to astronomer/issues#668
- Submitting this instead of https://github.com/astronomer/terraform-aws-astronomer-enterprise/pull/26