### PR TITLE
Add vars to enterprise module astronomer/issues#657

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,8 @@ module "aws" {
   worker_instance_type          = var.worker_instance_type
   db_instance_type              = var.db_instance_type
   db_replica_count              = var.db_replica_count
+  engine_version                = var.engine_version
+  auto_minor_version_upgrade    = var.auto_minor_version_upgrade
   allow_public_load_balancers   = var.allow_public_load_balancers
   # It makes the installation easier to leave
   # this public, then just flip it off after

--- a/variables.tf
+++ b/variables.tf
@@ -147,3 +147,15 @@ variable "astronomer_helm_values" {
   description = "Values in raw yaml to pass to Helm to override defaults in Astronomer Helm chart. Please see the Astronomer Helm chart's values.yaml for options. global.baseDomain is required. https://github.com/astronomer/astronomer/blob/master/values.yaml"
   type        = string
 }
+
+variable "engine_version" {
+  description = "Aurora database engine version."
+  type        = string
+  default     = "10.7"
+}
+
+variable "auto_minor_version_upgrade" {
+  description = "Determines whether minor engine upgrades will be performed automatically in the maintenance window for aurora db"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
- Add vars for aurora engine version and auto minor upgrade to enterprise module
- Draft until we have these merged into aws module
- Related to https://github.com/astronomer/terraform-aws-astronomer-aws/pull/41
- Related to https://github.com/astronomer/issues/issues/657