### PR TITLE
Bump astronomer version

### DIFF
--- a/examples/from_scratch/main.tf
+++ b/examples/from_scratch/main.tf
@@ -44,6 +44,7 @@ module "astronomer_aws_from_scratch" {
     # For example, astro.your-route53-domain.com
     baseDomain: ${var.deployment_id}.${var.route53_domain}
     tlsSecret: astronomer-tls
+    postgresqlEnabled: false
   nginx:
     privateLoadBalancer: false
   astronomer:

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ module "astronomer" {
   dependencies = [module.system_components.depended_on, module.aws.depended_on]
 
   source  = "astronomer/astronomer/kubernetes"
-  version = "1.1.59"
+  version = "1.1.88"
   # source               = "../terraform-kubernetes-astronomer"
 
   astronomer_version   = var.astronomer_version

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.10.2"
+  default     = "0.12.1-rc.2"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.12.0"
+  default     = "0.12.1-rc.5"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.12.1-rc.5"
+  default     = "0.12.1-rc.6"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -100,12 +100,12 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.12.1-rc.2"
+  default     = "0.12.0"
   type        = string
 }
 
 variable "cluster_version" {
-  default = "1.13"
+  default = "1.15"
   type    = string
 }
 


### PR DESCRIPTION
- Bump `terraform-kubernetes-astronomer` module to `1.1.88`
- Bump astronomer version to `0.12.1-rc.2` (to be changed)
- Related to astronomer/issues#1001
- CI will fail due to `postgresqlEnabled: true`
```
Error: rpc error: code = Unknown desc = release astronomer failed: secrets "astronomer-bootstrap" already exists
```
- This should pass once we update the astronomer version to a later release
