### PR TITLE
Add support for helm3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ data "aws_region" "current" {}
 module "system_components" {
   dependencies = [module.aws.depended_on]
   source       = "astronomer/astronomer-system-components/kubernetes"
-  version      = "0.1.20"
+  version      = "0.1.21"
   # source       = "../terraform-kubernetes-astronomer-system-components"
   enable_istio                  = false
   enable_aws_cluster_autoscaler = true

--- a/main.tf
+++ b/main.tf
@@ -38,18 +38,15 @@ module "aws" {
 # Get the AWS_REGION used by the aws provider
 data "aws_region" "current" {}
 
-# install tiller, which is the server-side component
-# of Helm, the Kubernetes package manager
 module "system_components" {
   dependencies = [module.aws.depended_on]
   source       = "astronomer/astronomer-system-components/kubernetes"
-  version      = "0.1.3"
+  version      = "0.1.3" # this will need to be bumped
   # source       = "../terraform-kubernetes-astronomer-system-components"
   enable_istio                  = false
   enable_aws_cluster_autoscaler = true
   cluster_name                  = module.aws.cluster_name
   aws_region                    = data.aws_region.current.name
-  tiller_version                = "2.16.7"
 }
 
 module "astronomer" {

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ data "aws_region" "current" {}
 module "system_components" {
   dependencies = [module.aws.depended_on]
   source       = "astronomer/astronomer-system-components/kubernetes"
-  version      = "0.1.3" # this will need to be bumped
+  version      = "0.1.3"
   # source       = "../terraform-kubernetes-astronomer-system-components"
   enable_istio                  = false
   enable_aws_cluster_autoscaler = true

--- a/main.tf
+++ b/main.tf
@@ -41,12 +41,13 @@ data "aws_region" "current" {}
 module "system_components" {
   dependencies = [module.aws.depended_on]
   source       = "astronomer/astronomer-system-components/kubernetes"
-  version      = "0.1.3"
+  version      = "0.1.20"
   # source       = "../terraform-kubernetes-astronomer-system-components"
   enable_istio                  = false
   enable_aws_cluster_autoscaler = true
   cluster_name                  = module.aws.cluster_name
   aws_region                    = data.aws_region.current.name
+  enable_tiller                 = false
 }
 
 module "astronomer" {

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:alpine
 
-ARG HELM_VERSION="v2.16.1"
+ARG HELM_VERSION="v3.2.4"
 ARG KUBECTL_VERSION="v1.12.0"
-ARG TERRAFORM_VERSION="0.12.20"
+ARG TERRAFORM_VERSION="0.12.26"
 
 RUN apk add --no-cache ca-certificates bash curl git \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \

--- a/provider_workaround.tf
+++ b/provider_workaround.tf
@@ -22,7 +22,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  version         = "~> 1.2"
+  version = "~> 1.2"
   kubernetes {
     host                   = module.aws.kube_endpoint
     cluster_ca_certificate = module.aws.kube_ca_certificate

--- a/provider_workaround.tf
+++ b/provider_workaround.tf
@@ -22,10 +22,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  version         = "~> 0.10"
-  service_account = "tiller"
-  namespace       = "kube-system"
-  install_tiller  = false
+  version         = "~> 1.2"
   kubernetes {
     host                   = module.aws.kube_endpoint
     cluster_ca_certificate = module.aws.kube_ca_certificate

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.15.3"
+  default     = "0.15.5"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -100,12 +100,12 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.13.1"
+  default     = "0.15.3"
   type        = string
 }
 
 variable "cluster_version" {
-  default = "1.15"
+  default = "1.16"
   type    = string
 }
 


### PR DESCRIPTION
- Bump helm provider to `~> 1.2`. This version supports helm3 and drops support for helm2 https://github.com/hashicorp/terraform-provider-helm/tree/v1.2.3
- Remove unnecessary variables from helm provider and system-components
- Bump default Astronomer version to `0.15.5`
- Bump default EKS version to `1.16.x`
~- Dependent on https://github.com/astronomer/terraform-kubernetes-astronomer-system-components/pull/13 (draft until merged)~
- Related to https://github.com/astronomer/issues/issues/1381