### PR TITLE
Added ability to retrieve private hosted zones from data source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,8 +78,9 @@ data "aws_elb" "nginx_lb" {
 }
 
 data "aws_route53_zone" "selected" {
-  count = var.create_record ? 1 : 0
-  name  = "${var.route53_domain}."
+  count        = var.create_record ? 1 : 0
+  name         = "${var.route53_domain}."
+  private_zone = var.private_hosted_zone
 }
 
 resource "aws_route53_record" "astronomer" {

--- a/variables.tf
+++ b/variables.tf
@@ -153,3 +153,9 @@ variable "install_astronomer_helm_chart" {
   default     = true
   description = "When false, this module skips installing the Astronomer helm chart. This is useful if you want to manage Astronomer outside of Terraform"
 }
+
+variable "private_hosted_zone" {
+  type        = bool
+  default     = false
+  description = "Set to true if you are using a private hosted zone. This allows the private zone to be retrieved."
+}


### PR DESCRIPTION
Astronomer Enterprise by default supports public hosted zones.

In cases where a user wishes to use a private hosted zone, the `aws_route53_zone` data source used in the module, would fail to retrieve it. This is because it needs to have the attribute `private_zone` to be set to `true` to get private hosted zones.

This change adds the capability to provide this value as an optional variable when using private zones. It is set to false by default if not provided.