### PR TITLE
Bump AWS Module to include CIDR range var for bastion

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ data "aws_lambda_invocation" "elb_name" {
 }
 
 data "aws_elb" "nginx_lb" {
-  name = data.aws_lambda_invocation.elb_name.result_map["Name"]
+  name = jsondecode(data.aws_lambda_invocation.elb_name.result).Name
 }
 
 data "aws_route53_zone" "selected" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "aws" {
   source  = "astronomer/astronomer-aws/aws"
-  version = "1.1.136"
+  version = "1.1.144"
   # source                        = "../terraform-aws-astronomer-aws"
   deployment_id                 = var.deployment_id
   admin_email                   = var.email


### PR DESCRIPTION
- Bump AWS module to include CIDR range var for bastion
- https://github.com/astronomer/terraform-aws-astronomer-aws/pull/45
- `result_map` has been deprecated and causes errors when using AWS provider `v3.0.0`
```
result_map - (DEPRECATED) This field is set only if result is a map of primitive types, where the map is string keys and string values. In Terraform 0.12 and later, use the jsondecode() function with the result attribute instead to convert the result to all supported native Terraform types.
```