### PR TITLE
Bump Astronomer Version to v0.16.8

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: terraform-aws-astronomer-enterprise
 steps:
 
 - name: lint
-  image: hashicorp/terraform:light
+  image: hashicorp/terraform:0.12.29
   commands:
     - cp providers.tf.example providers.tf
     - terraform init

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.16.2"
+  default     = "0.16.8"
   type        = string
 }
 


### PR DESCRIPTION
- Change default Astronomer version to 0.16.8
- Pin terraform image in CI to v0.12.29 to avoid 0.13.x (not yet supported)
- Related to https://github.com/astronomer/issues/issues/1896