### PR TITLE
Add support for Terraform 0.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
       - image: quay.io/astronomer/ci-pre-commit:2020-12
     steps:
       - checkout
-      - run: terraform init
       - run: pre-commit run --all-files
   terraform_lint:
     docker:
@@ -42,7 +41,7 @@ jobs:
     steps:
       - checkout
       - run: git remote set-url origin "https://astro-astronomer:${GITHUB_TOKEN}@github.com/astronomer/${CIRCLE_PROJECT_REPONAME}.git"
-      - run: git tag 1.2.<< pipeline.number >>
+      - run: git tag 2.0.<< pipeline.number >>
       - run: git push origin << pipeline.git.branch >> --tags
       - slack/notify:
           event: fail

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Install the necessary tools:
 
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
 - [AWS IAM Authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html)
-- [Terraform](https://www.terraform.io/downloads.html) _Use version 0.12.3 or later_
-- [Helm client](https://github.com/helm/helm#install) _Use version 2, 2.14.1 or later_
+- [Terraform](https://www.terraform.io/downloads.html) _Use version 0.13.5 or later_
+- [Helm client](https://github.com/helm/helm#install) _Use version 3, 3.3.4 or later_
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) _Use the version appropriate for your Kubernetes cluster version_
 
 ## Installation
@@ -70,7 +70,12 @@ provider "acme" {
 }
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    acme = {
+      source = "terraform-providers/acme"
+    }
+  }
   backend "s3" {
 	  bucket  = "astronomer-platform"
 	  key	    = "terraform-state"

--- a/examples/from_scratch/main.tf
+++ b/examples/from_scratch/main.tf
@@ -69,3 +69,11 @@ output "windows_debug_box_hostname" {
   value = module.astronomer_aws_from_scratch.windows_debug_box_hostname
 }
 
+terraform {
+  required_providers {
+    acme = {
+      source = "terraform-providers/acme"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/from_scratch/main.tf
+++ b/examples/from_scratch/main.tf
@@ -68,3 +68,12 @@ output "windows_debug_box_password" {
 output "windows_debug_box_hostname" {
   value = module.astronomer_aws_from_scratch.windows_debug_box_hostname
 }
+
+terraform {
+  required_providers {
+    acme = {
+      source = "terraform-providers/acme"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/from_scratch/main.tf
+++ b/examples/from_scratch/main.tf
@@ -75,5 +75,4 @@ terraform {
       source = "terraform-providers/acme"
     }
   }
-  required_version = ">= 0.13"
 }

--- a/examples/from_scratch/main.tf
+++ b/examples/from_scratch/main.tf
@@ -74,6 +74,9 @@ terraform {
     acme = {
       source = "terraform-providers/acme"
     }
+    aws = {
+      source = "hashicorp/aws"
+    }
   }
   required_version = ">= 0.13"
 }

--- a/examples/from_scratch/main.tf
+++ b/examples/from_scratch/main.tf
@@ -69,14 +69,3 @@ output "windows_debug_box_hostname" {
   value = module.astronomer_aws_from_scratch.windows_debug_box_hostname
 }
 
-terraform {
-  required_providers {
-    acme = {
-      source = "terraform-providers/acme"
-    }
-    aws = {
-      source = "hashicorp/aws"
-    }
-  }
-  required_version = ">= 0.13"
-}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "aws" {
   source  = "astronomer/astronomer-aws/aws"
-  version = "1.2.96"
+  version = "2.0.103"
   # source                        = "../terraform-aws-astronomer-aws"
   deployment_id                 = var.deployment_id
   admin_email                   = var.email

--- a/pipeline/lint.sh
+++ b/pipeline/lint.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2044
 set -xe
 
-TERRAFORM="${TERRAFORM:-terraform-0.12}"
+TERRAFORM="${TERRAFORM:-terraform-0.13}"
 
 $TERRAFORM -v
 

--- a/pipeline/run_terraform.sh
+++ b/pipeline/run_terraform.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xe
 
-TERRAFORM="${TERRAFORM:-terraform-0.12}"
+TERRAFORM="${TERRAFORM:-terraform-0.13}"
 
 $TERRAFORM -v
 

--- a/providers.tf.example
+++ b/providers.tf.example
@@ -11,9 +11,6 @@ terraform {
     acme = {
       source = "terraform-providers/acme"
     }
-    aws = {
-      source = "hashicorp/aws"
-    }
   }
   required_version = ">= 0.13"
 }

--- a/providers.tf.example
+++ b/providers.tf.example
@@ -5,12 +5,3 @@ provider "aws" {
 provider "acme" {
   server_url = "https://acme-v02.api.letsencrypt.org/directory"
 }
-
-terraform {
-  required_providers {
-    acme = {
-      source = "terraform-providers/acme"
-    }
-  }
-  required_version = ">= 0.13"
-}

--- a/providers.tf.example
+++ b/providers.tf.example
@@ -5,3 +5,15 @@ provider "aws" {
 provider "acme" {
   server_url = "https://acme-v02.api.letsencrypt.org/directory"
 }
+
+terraform {
+  required_providers {
+    acme = {
+      source = "terraform-providers/acme"
+    }
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -100,12 +100,12 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.16.8"
+  default     = "0.16.12"
   type        = string
 }
 
 variable "cluster_version" {
-  default = "1.17"
+  default = "1.18"
   type    = string
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -13,5 +13,8 @@ terraform {
     local = {
       source = "hashicorp/local"
     }
+    acme = {
+      source = "terraform-providers/acme"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,17 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
 }


### PR DESCRIPTION
- Bump release tags to `2.0.x`
- Update README with relevant versions
- Bump default Astronomer version to `0.16.12`
- Bump default EKS version to `1.18`
- Add necessary changes for terraform 0.13 support
- Related to https://github.com/astronomer/issues/issues/1910