### PR TITLE
Update tag value in slack notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Tag*:\n1.2.<< pipeline.number >>"
+                      "text": "*Tag*:\n2.0.<< pipeline.number >>"
                     }
                   ],
                   "accessory": {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "aws" {
   source  = "astronomer/astronomer-aws/aws"
-  version = "2.0.103"
+  version = "2.0.108"
   # source                        = "../terraform-aws-astronomer-aws"
   deployment_id                 = var.deployment_id
   admin_email                   = var.email

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.16.12"
+  default     = "0.16.15"
   type        = string
 }
 


### PR DESCRIPTION
- Slack notifications for successful tags show the wrong tag 1.2.x
- Update to proper tag 2.0.x
- Same as https://github.com/astronomer/terraform-aws-astronomer-aws/pull/55
- Bump astronomer version to `0.16.15`
- Bump `terraform-aws-astronomer-aws` module version
