### PR TITLE
Install Astronomer 0.23.9

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "aws" {
   source  = "astronomer/astronomer-aws/aws"
-  version = "2.0.108"
+  version = "2.0.114"
   # source                        = "../terraform-aws-astronomer-aws"
   deployment_id                 = var.deployment_id
   admin_email                   = var.email

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.16.15"
+  default     = "0.23.9"
   type        = string
 }
 


### PR DESCRIPTION
- Set default Astronomer version to v0.23.9
- Bump astronomer-aws module to 2.0.114