### PR TITLE
Lets users pick aurora postgres engine version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ module "aws" {
   cluster_version               = var.cluster_version
   worker_instance_type          = var.worker_instance_type
   db_instance_type              = var.db_instance_type
+  engine_version                = var.db_instance_engine_version
   db_replica_count              = var.db_replica_count
   allow_public_load_balancers   = var.allow_public_load_balancers
   # It makes the installation easier to leave

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "aws" {
   source  = "astronomer/astronomer-aws/aws"
-  version = "2.0.114"
+  version = "2.0.122"
   # source                        = "../terraform-aws-astronomer-aws"
   deployment_id                 = var.deployment_id
   admin_email                   = var.email

--- a/variables.tf
+++ b/variables.tf
@@ -131,6 +131,12 @@ variable "db_instance_type" {
   type    = string
 }
 
+variable "db_instance_engine_version" {
+  default = "11.9"
+  type = string
+  description = "The AWS Aurora RDS PostgreSQL engine version number."
+}
+
 variable "worker_instance_type" {
   default = "m5.xlarge"
   type    = string


### PR DESCRIPTION
This allows anybody doing an a quick installation to pick the AWS RDS Aurora PostgreSQL version. The current default (10.7) is no longer supported by AWS, which is causing the install to fail.