### PR TITLE
Bumped up astronomer platform version to 0.23.12 as default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "ten_dot_what_cidr" {
 
 variable "astronomer_version" {
   description = "Version of the Astronomer platform installed"
-  default     = "0.23.9"
+  default     = "0.23.12"
   type        = string
 }
 


### PR DESCRIPTION
Modified `astronomer_version` variable under `variables.tf` to reflect `0.23.12` (latest) as default astronomer version.